### PR TITLE
update default config to use KAFKA

### DIFF
--- a/test_harness/config/default_config.config
+++ b/test_harness/config/default_config.config
@@ -2,16 +2,14 @@
 requests_max_retries = 5
 requests_timeout = 10
 
-metrics_from_kafka = False
+metrics_from_kafka = True
 kafka_metrics_host = host.docker.internal:9092
 kafka_metrics_topic = BenchmarkingProbe_service0
 kafka_metrics_collection_interval = 1
 
-message_bus_protocol = HTTP
+message_bus_protocol = KAFKA3
 kafka_message_bus_host = host.docker.internal:9092
 kafka_message_bus_topic = Protocol_Verifier_Reception
-
-testing_external_app = False
 
 [non-default]
 
@@ -19,13 +17,15 @@ testing_external_app = False
 # `log_calc_interval_time` will soon be deprecated and moved to test config
 log_calc_interval_time = 5
 aer_log_file_prefix = Reception
-ver_log_file_prefix = Verifier
+ver_log_file_prefix = pv
+
 get_log_file_url = http://host.docker.internal:9000/download/log-file
 get_log_file_names_url = http://host.docker.internal:9000/download/log-file-names
 
 pv_send_url = http://host.docker.internal:9000/upload/events
-pv_send_as_pv_bytes = False
-send_json_without_length_prefix = False
+pv_send_as_pv_bytes = True
+
+send_json_without_length_prefix = True
 
 pv_send_job_defs_url = http://host.docker.internal:9000/upload/job-definitions
 
@@ -35,7 +35,7 @@ pv_config_update_time = 60
 # `pv_finish_interval` will soon be deprecated and moved to test config
 pv_finish_interval = 30
 # `pv_test_timeout` will soon be deprecated and moved to test config
-pv_test_timeout = 5
+pv_test_timeout = 10
 
 pv_clean_folders_url = http://host.docker.internal:9000/io/cleanup-test
 pv_clean_folders_read_timeout = 300


### PR DESCRIPTION
To speed up ease of use with using the test harness with the protocol verifier, updated the default config to use KAFKA config properties.